### PR TITLE
Exclude identity provider from SAML attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,7 +594,8 @@
 
     function extractAttributes(xmlDoc) {
       const excludedAttributes = [
-        'authnmethodsreferences'
+        'authnmethodsreferences',
+        'identityprovider'
       ];
 
       const attributes = xmlDoc.querySelectorAll('Attribute, *|Attribute');


### PR DESCRIPTION
## Summary

This pull request makes a minor update to the attribute extraction logic in the `index.html` file for browser extensions. The change excludes the `identityprovider` attribute from being extracted, in addition to the already excluded `authnmethodsreferences` attribute.

## Outline of PR

This pull request makes a minor update to the attribute extraction logic in `index.html` for browser extensions. The change ensures that the `identityprovider` attribute is now excluded during XML attribute extraction, alongside the previously excluded `authnmethodsreferences`.