### PR TITLE
Add collapsible raw certificate (PEM) display

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,6 +192,28 @@
     .footer a:hover {
       text-decoration: underline;
     }
+    .cert-details {
+      margin-top: 12px;
+    }
+    .cert-details summary {
+      cursor: pointer;
+      font-size: 13px;
+      color: #0969da;
+      user-select: none;
+    }
+    .cert-details summary:hover {
+      text-decoration: underline;
+    }
+    .cert-raw {
+      margin-top: 8px;
+      padding: 12px;
+      background: #f6f8fa;
+      border-radius: 6px;
+      font-size: 11px;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
   </style>
 </head>
 <body>
@@ -263,6 +285,10 @@
           <div class="field-label">Signature Algorithm</div>
           <div class="field-value" id="certSigAlg">-</div>
         </div>
+        <details class="cert-details" id="certDetails" style="display: none;">
+          <summary>View raw certificate (PEM)</summary>
+          <pre class="cert-raw" id="certRaw"></pre>
+        </details>
       </div>
     </div>
 
@@ -361,6 +387,7 @@
         if (certElement) {
           const certBase64 = certElement.textContent.replace(/\s/g, '');
           parseCertificate(certBase64);
+          displayRawCertificate(certBase64);
         }
 
         // Extract SAML info
@@ -376,6 +403,18 @@
       const errorDiv = document.getElementById('error');
       errorDiv.textContent = message;
       errorDiv.style.display = 'block';
+    }
+
+    function displayRawCertificate(base64Cert) {
+      // Format as PEM
+      const pemLines = ['-----BEGIN CERTIFICATE-----'];
+      for (let i = 0; i < base64Cert.length; i += 64) {
+        pemLines.push(base64Cert.substring(i, i + 64));
+      }
+      pemLines.push('-----END CERTIFICATE-----');
+      
+      document.getElementById('certRaw').textContent = pemLines.join('\n');
+      document.getElementById('certDetails').style.display = 'block';
     }
 
     function parseCertificate(base64Cert) {
@@ -687,6 +726,10 @@
       // Clear and hide attributes section
       document.getElementById('attributesBody').innerHTML = '';
       document.getElementById('attributesSection').style.display = 'none';
+      
+      // Clear and hide certificate raw section
+      document.getElementById('certRaw').textContent = '';
+      document.getElementById('certDetails').style.display = 'none';
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary

This pull request adds a feature to display the raw X.509 certificate in PEM format on the page, enhancing certificate transparency for users. It introduces new UI elements and supporting styles, and ensures the certificate view is properly shown and hidden as needed.

## Outline of PR

Certificate raw view feature:

* Added a new `<details>` section with a summary and a `<pre>` block (`certDetails` and `certRaw`) to display the raw certificate in PEM format in the certificate display area.
* Implemented the `displayRawCertificate` JavaScript function to format the base64 certificate as PEM and show the raw certificate section. This function is called after parsing the certificate. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R408-R419) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R390)
* Updated the reset logic to clear and hide the raw certificate section when clearing the certificate display.

Styling improvements:

* Added CSS classes (`cert-details` and `cert-raw`) to style the raw certificate section, including spacing, font size, background, and interactive summary styling.